### PR TITLE
feat: add offline caching with service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,39 @@
-// sw.js – dumb service‐worker: claims control, but never caches.
-self.addEventListener('install', event => self.skipWaiting());
-self.addEventListener('activate',  event => self.clients.claim());
-// All fetches go straight to the network; if offline, let the browser decide.
+// Service worker providing offline capability with cached core assets.
+const CACHE_VERSION = 'v1';
+const CACHE_NAME = `stretching-timer-${CACHE_VERSION}`;
+
+// Assets required for the app shell. Update the list when adding new files.
+const CORE_ASSETS = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/script.js',
+  '/manifest.json',
+  '/icon-192.png',
+  '/icon-512.png',
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then(cache => cache.addAll(CORE_ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    fetch(event.request).catch(() => caches.match(event.request))
+  );
+});
+


### PR DESCRIPTION
## Summary
- cache core assets during service worker install
- serve cached files when offline
- use versioned cache names and clean up old caches on activate

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ecd308088331a96e0dff4fc8d6d5